### PR TITLE
Date selector

### DIFF
--- a/components/DateSelector/DateSelector.test.tsx
+++ b/components/DateSelector/DateSelector.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import dateUtils from './date';
+import DateSelector from './DateSelector';
+
+describe('DateSelector', () => {
+  test('renders', () => {
+    render(<DateSelector />);
+
+    const today = dateUtils.formatDate(new Date());
+    expect(screen.queryByText(today, { exact: false })).toBeInTheDocument();
+  });
+
+  test('buttons switch the date', async () => {
+    render(<DateSelector />);
+    const user = userEvent.setup();
+
+    const today = new Date();
+    const previous = dateUtils.getPreviousDate(today);
+
+    await user.click(screen.getByRole('button', { name: 'previous' }));
+    expect(screen.queryByText(dateUtils.formatDate(previous), { exact: false }))
+      .toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'next' }));
+    expect(screen.queryByText(dateUtils.formatDate(today), { exact: false }))
+      .toBeInTheDocument();
+  });
+});

--- a/components/DateSelector/DateSelector.tsx
+++ b/components/DateSelector/DateSelector.tsx
@@ -1,14 +1,25 @@
+import { useState } from 'react';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons';
-import { formatDate } from './date';
+import { formatDate, getNextDate, getPreviousDate } from './date';
 
 function DateSelector() {
+  const [current, setCurrent] = useState(new Date());
+
+  function handlePrevious() {
+    setCurrent(getPreviousDate(current));
+  }
+
+  function handleNext() {
+    setCurrent(getNextDate(current));
+  }
+
   return (
     <nav className="flex justify-end p-3 bg-lime-200">
-      <button type="button" className="align-middle p-1" aria-label="previous">
+      <button type="button" onClick={handlePrevious} className="align-middle p-1" aria-label="previous">
         <IconChevronLeft size={15} className="" role="presentation" />
       </button>
-      <span className="text-center min-w-100 mx-1">{formatDate(new Date())}</span>
-      <button type="button" className="align-middle p-1" aria-label="next">
+      <span className="text-center min-w-100 mx-1">{formatDate(current)}</span>
+      <button type="button" onClick={handleNext} className="align-middle p-1" aria-label="next">
         <IconChevronRight size={15} className="align-bottom" role="presentation" />
       </button>
     </nav>

--- a/components/DateSelector/DateSelector.tsx
+++ b/components/DateSelector/DateSelector.tsx
@@ -1,14 +1,5 @@
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons';
-
-export function formatDate(date: Date, options?: Intl.DateTimeFormatOptions) {
-  const dateOptions = options || {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-  };
-
-  return date.toLocaleDateString('en-US', dateOptions);
-}
+import { formatDate } from './date';
 
 function DateSelector() {
   return (

--- a/components/DateSelector/DateSelector.tsx
+++ b/components/DateSelector/DateSelector.tsx
@@ -1,0 +1,27 @@
+import { IconChevronLeft, IconChevronRight } from '@tabler/icons';
+
+export function formatDate(date: Date, options?: Intl.DateTimeFormatOptions) {
+  const dateOptions = options || {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  };
+
+  return date.toLocaleDateString('en-US', dateOptions);
+}
+
+function DateSelector() {
+  return (
+    <nav className="flex justify-end p-3 bg-lime-200">
+      <button type="button" className="align-middle p-1" aria-label="previous">
+        <IconChevronLeft size={15} className="" role="presentation" />
+      </button>
+      <span className="text-center min-w-100 mx-1">{formatDate(new Date())}</span>
+      <button type="button" className="align-middle p-1" aria-label="next">
+        <IconChevronRight size={15} className="align-bottom" role="presentation" />
+      </button>
+    </nav>
+  );
+}
+
+export default DateSelector;

--- a/components/DateSelector/date.test.ts
+++ b/components/DateSelector/date.test.ts
@@ -1,0 +1,31 @@
+import { formatDate, getNextDate, getPreviousDate } from './date';
+
+describe('date utils', () => {
+  test('date is formatted correctly', () => {
+    const date = new Date('2022-07-29');
+
+    const formattedDate = formatDate(date);
+    expect(formattedDate).toBe('Fri, Jul 29');
+
+    const formattedDateWithOptions = formatDate(date, { weekday: 'long' });
+    expect(formattedDateWithOptions).toBe('Friday');
+  });
+
+  test('returns the correct previous date', () => {
+    const date = new Date('2020-03-12');
+
+    const previous = getPreviousDate(date);
+    expect(previous.getDate()).toBe(11);
+    expect(previous.getMonth()).toBe(2);
+    expect(previous.getFullYear()).toBe(2020);
+  });
+
+  test('returns the correct next date', () => {
+    const date = new Date('2021-12-31');
+
+    const next = getNextDate(date);
+    expect(next.getDate()).toBe(1);
+    expect(next.getMonth()).toBe(0);
+    expect(next.getFullYear()).toBe(2022);
+  });
+});

--- a/components/DateSelector/date.ts
+++ b/components/DateSelector/date.ts
@@ -1,0 +1,11 @@
+export function formatDate(date: Date, options?: Intl.DateTimeFormatOptions) {
+  const dateOptions = options || {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  };
+
+  return date.toLocaleDateString('en-US', dateOptions);
+}
+
+export default { formatDate };

--- a/components/DateSelector/date.ts
+++ b/components/DateSelector/date.ts
@@ -8,4 +8,18 @@ export function formatDate(date: Date, options?: Intl.DateTimeFormatOptions) {
   return date.toLocaleDateString('en-US', dateOptions);
 }
 
-export default { formatDate };
+export function getPreviousDate(date: Date) {
+  const previous = new Date(date.getTime());
+  previous.setDate(date.getDate() - 1);
+
+  return previous;
+}
+
+export function getNextDate(date: Date) {
+  const next = new Date(date.getTime());
+  next.setDate(date.getDate() + 1);
+
+  return next;
+}
+
+export default { formatDate, getPreviousDate, getNextDate };

--- a/components/DateSelector/date.ts
+++ b/components/DateSelector/date.ts
@@ -4,7 +4,7 @@ export function formatDate(date: Date, options?: Intl.DateTimeFormatOptions) {
   const dateOptions = options || {
     weekday: 'short',
     month: 'short',
-    day: 'numeric',
+    day: '2-digit',
     ...(!isCurrentYear && { year: 'numeric' }),
   };
 

--- a/components/DateSelector/date.ts
+++ b/components/DateSelector/date.ts
@@ -1,8 +1,11 @@
 export function formatDate(date: Date, options?: Intl.DateTimeFormatOptions) {
+  const isCurrentYear = (new Date()).getFullYear() === date.getFullYear();
+
   const dateOptions = options || {
     weekday: 'short',
     month: 'short',
     day: 'numeric',
+    ...(!isCurrentYear && { year: 'numeric' }),
   };
 
   return date.toLocaleDateString('en-US', dateOptions);

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,5 +1,10 @@
 /* eslint-disable import/prefer-default-export */
 import Main from './Main/Main';
 import Counter from './Counter/Counter';
+import DateSelector from './DateSelector/DateSelector';
 
-export { Main, Counter };
+export {
+  Main,
+  Counter,
+  DateSelector,
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,7 @@
 import { InferGetServerSidePropsType } from 'next';
 import Head from 'next/head';
-import { IconChevronLeft, IconChevronRight } from '@tabler/icons';
 import { loadFoods } from './api/foods';
-import { Counter } from '../components';
-
-const dateOptions: Intl.DateTimeFormatOptions = {
-  weekday: 'short',
-  month: 'short',
-  day: 'numeric',
-};
+import { Counter, DateSelector } from '../components';
 
 function Home({ foods }: InferGetServerSidePropsType<typeof getStaticProps>) {
   return (
@@ -21,11 +14,7 @@ function Home({ foods }: InferGetServerSidePropsType<typeof getStaticProps>) {
       <div className="flex flex-col items-center p-8 h-screen">
         <h1 className="text-6xl font-medium text-center">Caroline</h1>
         <main className="w-3/5 mt-10 bg-gray-100">
-          <nav className="text-right p-3 bg-lime-200">
-            <button type="button" className="mx-2 align-middle" aria-label="previous"><IconChevronLeft size={15} className="" role="presentation" /></button>
-            <span>{(new Date()).toLocaleDateString('en-US', dateOptions)}</span>
-            <button type="button" className="mx-2 align-middle" aria-label="next"><IconChevronRight size={15} className="align-bottom" role="presentation" /></button>
-          </nav>
+          <DateSelector />
           {foods?.map((food) => (
             <div className="flex bg-zinc-50 p-5" key={food.id}>
               <h3 className="flex-grow capitalize">{food.name}</h3>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,7 +11,7 @@ function Home({ foods }: InferGetServerSidePropsType<typeof getStaticProps>) {
         <meta name="description" content="The web version of the Dr. Greger's app Daily Dozen, which helps you track if you getting enough servings of the healthiest foods" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <div className="flex flex-col items-center p-8 h-screen">
+      <div className="flex flex-col items-center p-8 min-h-screen">
         <h1 className="text-6xl font-medium text-center">Caroline</h1>
         <main className="w-3/5 mt-10 bg-gray-100">
           <DateSelector />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,11 @@ module.exports = {
     './components/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      minWidth: {
+        100: '100px',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
Adds date selector functionality. Can switch between dates (previous and next).

Tests are included.

The only thing of note is when the date includes the year, the container for it grows. That causes the previous button to move around. I've added extra padding on the buttons so it's more easily clickable, even when moving. It's not perfect, but I think it works for now.